### PR TITLE
Cease defining prettier config in eslint config

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,12 @@
+module.exports = {
+  printWidth: 100,
+  tabs: false,
+  semi: true,
+  singleQuote: true,
+  trailingComma: 'es5',
+  endOfLine: 'lf',
+  tabWidth: 2,
+  bracketSpacing: true,
+  bracketSameLine: true,
+  arrowParens: 'always',
+};

--- a/base.js
+++ b/base.js
@@ -11,21 +11,7 @@ module.exports = {
     sourceType: 'module',
   },
   rules: {
-    'prettier/prettier': [
-      'error',
-      {
-        printWidth: 100,
-        tabs: false,
-        semi: true,
-        singleQuote: true,
-        trailingComma: 'es5',
-        endOfLine: 'lf',
-        tabWidth: 2,
-        bracketSpacing: true,
-        bracketSameLine: true,
-        arrowParens: 'always',
-      },
-    ],
+    'prettier/prettier': ['error'],
     'no-use-before-define': ['error', { functions: false, classes: true, variables: true }],
     'no-plusplus': 'off',
     'consistent-return': 'off',

--- a/mdx.js
+++ b/mdx.js
@@ -1,17 +1,3 @@
-const prettierCfg = {
-  printWidth: 100,
-  tabs: false,
-  semi: true,
-  singleQuote: true,
-  trailingComma: 'es5',
-  endOfLine: 'lf',
-  tabWidth: 2,
-  bracketSpacing: true,
-  bracketSameLine: true,
-  arrowParens: 'always',
-  proseWrap: 'always',
-};
-
 module.exports = {
   extends: ['plugin:mdx/recommended', 'plugin:prettier/recommended'],
 
@@ -32,7 +18,6 @@ module.exports = {
     'prettier/prettier': [
       'error',
       {
-        ...prettierCfg,
         parser: 'mdx',
       },
     ],
@@ -45,7 +30,6 @@ module.exports = {
         'prettier/prettier': [
           'error',
           {
-            ...prettierCfg,
             parser: 'markdown',
           },
         ],


### PR DESCRIPTION
As discussed on Discord:

Developers that use both an ESLint and Prettier extension will have a non-cooperative experience with the tools because the Prettier configuration is defined within the ESLint configuration. I have an extension for both ESLint and Prettier. They both seek out their own config files.

See [here](https://github.com/prettier/eslint-plugin-prettier#options) how the prettier plugin recommends against doing what has been done:

```
Note: While it is possible to pass options to Prettier via your ESLint configuration file, it is not recommended because editor extensions such as prettier-atom and prettier-vscode will read .prettierrc, but won't read settings from ESLint, which can lead to an inconsistent experience.
```

---

I will also open up PRs in the other repositories to define a `.prettierrc` file with the same configuration used here. This should not affect CI nor users who don't have extensions for each tool.