### PR TITLE
changed the way of installing react hooks plugin

### DIFF
--- a/configs/react.js
+++ b/configs/react.js
@@ -6,10 +6,16 @@ import { adjustESLintConfigFiles } from './base.js';
 const reactConfig = [
 	pluginReact.configs.flat.recommended,
 	{
-    plugins: {
-        'react-hooks': pluginReactHooks
-    }
-  },
+		plugins: {
+			'react-hooks': {
+				rules: pluginReactHooks.rules,
+			},
+		},
+		rules: {
+			'react-hooks/rules-of-hooks': 'error',
+			'react-hooks/exhaustive-deps': 'warn',
+		},
+	},
 	{
 		rules: {
 			// While using ts with `react-jsx` preset - there

--- a/configs/react.js
+++ b/configs/react.js
@@ -5,7 +5,11 @@ import { adjustESLintConfigFiles } from './base.js';
 /** @var {Linter.Config[]} */
 const reactConfig = [
 	pluginReact.configs.flat.recommended,
-	pluginReactHooks.configs.recommended,
+	{
+    plugins: {
+        'react-hooks': pluginReactHooks
+    }
+  },
 	{
 		rules: {
 			// While using ts with `react-jsx` preset - there


### PR DESCRIPTION
In the new version of eslint, plugins must be in object form, and pluginReactHooks itself uses an array